### PR TITLE
Only import requests in flickr mode

### DIFF
--- a/glitch_random.py
+++ b/glitch_random.py
@@ -40,7 +40,6 @@ import os
 import sys
 import getopt
 import webbrowser
-import requests
 from PIL import Image
 from collections import Counter, defaultdict
 from StringIO import StringIO
@@ -69,6 +68,7 @@ class glitch():
 
         # if not from_file, path is a URL to image online
         else:
+            import requests
             self.data = requests.get(path).content
             # use regex to extract name (id) for image from end of URL
             # after final backslash (greedy match) but before '_'

--- a/utils.py
+++ b/utils.py
@@ -1,6 +1,6 @@
 import os, subprocess, glob
 import re
-import webbrowser, requests
+import webbrowser
 import random
 
 
@@ -60,6 +60,7 @@ class flickr_browse():
         if write:
             # write image data to file in directory specified by global PATH_OUT
             outfile = outfile_path( self.outdir, '{}.jpg'.format(d_hit['id']) )
+            import requests
             with open(outfile, "w") as file_out:
                 file_out.write( requests.get(hit_url).content )
 


### PR DESCRIPTION
The other imports are builtins, so file mode can be used without
installing anything.